### PR TITLE
Исправляем ошибку получения значения для экрана

### DIFF
--- a/include/classes/IoTItem.h
+++ b/include/classes/IoTItem.h
@@ -44,6 +44,7 @@ class IoTItem {
     virtual IoTGpio* getGpioDriver();
     virtual void setValue(IoTValue Value);
     virtual void setValue(String valStr);
+    String getRoundValue();
 
     //методы для графиков
     virtual void publishValue();

--- a/src/classes/IoTItem.cpp
+++ b/src/classes/IoTItem.cpp
@@ -52,20 +52,7 @@ void IoTItem::loop() {
 //получить
 String IoTItem::getValue() {
     if (value.isDecimal) {
-        if (_multiply) value.valD = value.valD * _multiply;
-        if (_plus) value.valD = value.valD + _plus;
-        if (_round >= 0 && _round <= 6) {
-            int sot = _round ? pow(10, (int)_round) : 1;
-            value.valD = round(value.valD * sot) / sot;
-        }
-        if (_map1 != _map2) value.valD = map(value.valD, _map1, _map2, _map3, _map4);
-
-        if (_round >= 0 && _round <= 6) {
-            char buf[15];
-            sprintf(buf, ("%1." + (String)_round + "f").c_str(), value.valD);
-            return value.valS = buf;
-        } else
-            return (String)value.valD;
+        return getRoundValue();
     } else
         return value.valS;
 }
@@ -114,9 +101,27 @@ void IoTItem::regEvent(String value, String consoleInfo = "") {
     //========================================================================
 }
 
+String IoTItem::getRoundValue() {
+    if (_round >= 0 && _round <= 6) {
+        int sot = _round ? pow(10, (int)_round) : 1;
+        value.valD = round(value.valD * sot) / sot;
+        
+        char buf[15];
+        sprintf(buf, ("%1." + (String)_round + "f").c_str(), value.valD);
+        return (String)buf;
+    } else {
+        return (String)value.valD;
+    }
+}
+
 void IoTItem::regEvent(float regvalue, String consoleInfo = "") {
     value.valD = regvalue;
-    regEvent(getValue(), consoleInfo);
+
+    if (_multiply) value.valD = value.valD * _multiply;
+    if (_plus) value.valD = value.valD + _plus;
+    if (_map1 != _map2) value.valD = map(value.valD, _map1, _map2, _map3, _map4);
+    
+    regEvent(getRoundValue(), consoleInfo);
 }
 
 void IoTItem::doByInterval() {}

--- a/src/modules/display/Lcd2004/Lcd2004.cpp
+++ b/src/modules/display/Lcd2004/Lcd2004.cpp
@@ -36,9 +36,11 @@ class Lcd2004 : public IoTItem {
             LCDI2C = new LiquidCrystal_I2C(hexStringToUint8(addr), w, h);
             if (LCDI2C != nullptr) {
                 LCDI2C->init();
-                LCDI2C->backlight();
             }
         }
+            
+        LCDI2C->clear();
+        LCDI2C->backlight();
 
         jsonRead(parameters, "coord", xy);
         _x = selectFromMarkerToMarker(xy, ",", 0).toInt();
@@ -52,14 +54,13 @@ class Lcd2004 : public IoTItem {
         if (LCDI2C != nullptr) {
             printBlankStr(_prevStrSize);
             
-            String tmpStr = "";
-            if (_descr != "none") tmpStr = _descr + " " + getItemValue(_id2show);
-                else tmpStr = getItemValue(_id2show);
+            String tmpStr = getItemValue(_id2show);
+            if (_descr != "none") tmpStr = _descr + " " + tmpStr;
             LCDI2C->setCursor(_x, _y);
             LCDI2C->print(tmpStr);
             
             //LCDI2C->print("Helloy,Manager 404 !");
-
+            //Serial.printf("ffff %s\n", _id2show);
             _prevStrSize = tmpStr.length();
         }
     }
@@ -113,7 +114,10 @@ class Lcd2004 : public IoTItem {
         LCDI2C->print(tmpStr);
     }
 
-    ~Lcd2004(){};
+    ~Lcd2004(){
+        if (LCDI2C) delete LCDI2C;
+        LCDI2C = nullptr;
+    };
 };
 
 void *getAPI_Lcd2004(String subtype, String param) {


### PR DESCRIPTION
Исправляем ошибку с получением значения IoTItem через getValue(), точнее вызывалось двойное преобразование map. Перестроил порядок применения модификаторов и выделил getRoundValue() как вариант получения округленного только значения из численного значения. Значение уже изменено модификаторами.