### PR TITLE
bugfix pulse() & mqtt settings save

### DIFF
--- a/src/MqttClient.cpp
+++ b/src/MqttClient.cpp
@@ -104,6 +104,8 @@ void getMqttData() {
     mqttPort = jsonReadInt(settingsFlashJson, F("mqttPort"));
     mqttUser = jsonReadStr(settingsFlashJson, F("mqttUser"));
     mqttPass = jsonReadStr(settingsFlashJson, F("mqttPass"));
+    mqttPrefix = jsonReadStr(settingsFlashJson, F("mqttPrefix"));
+    mqttRootDevice = mqttPrefix + "/" + chipId;
 }
 
 void mqttSubscribe() {

--- a/src/modules/exec/ButtonOut/ButtonOut.cpp
+++ b/src/modules/exec/ButtonOut/ButtonOut.cpp
@@ -53,8 +53,8 @@ class ButtonOut : public IoTItem {
 
     void setValue(const IoTValue& Value, bool genEvent = true) {
         value = Value;
-        if ((value.valD == !_inv?1:0) && (_interval != 0)) {
-            value.valD = !_inv?1:0;
+        if ((value.valD == 1) && (_interval != 0)) {
+            // value.valD = !_inv?1:0;
             enableDoByInt = true;
             // SerialPrint("I", "ButtonOut","single pulse start");
             suspendNextDoByInt(_interval);


### PR DESCRIPTION
1. bugfix pulse(): не работал при inv=1
2. теперь при измении настроек mqtt в web после сохранения mqtt сразу их применяет, т.е. перезагружаться не нужно как раньше.